### PR TITLE
Optimize feed generation and caching

### DIFF
--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -3,6 +3,8 @@ import assert from 'assert'
 import * as cheerio from 'cheerio'
 import { Feed } from 'feed'
 
+export const dynamic = 'force-static'
+
 export async function GET(req: Request) {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
 
@@ -65,7 +67,7 @@ export async function GET(req: Request) {
     status: 200,
     headers: {
       'content-type': 'application/xml',
-      'cache-control': 's-maxage=31556952',
+      'Cache-Control': 's-maxage=3600, stale-while-revalidate=86400',
     },
   })
 }


### PR DESCRIPTION
Force static generation of the feed route to generate it at build time. Update Cache-Control headers to use a shorter `s-maxage` and include `stale-while-revalidate` for better cache management.